### PR TITLE
Feature: Ability to change item expiration time

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,30 @@ console.log(memoryCache.retrieveItemValue('key1')); // Logs to console: 1
 console.log(memoryCache.retrieveItemValue('notFound')); // Logs to console: undefined
 ```
 
+### Changing the item expiration timestamp
+You can set the item expiration time for both permanent and already expiring items.
+
+#### With a relative expiration time
+```ts
+import { MemoryCache } from 'memory-cache-node';
+
+const memoryCache = new MemoryCache<string, number>(600, 1000000);
+memoryCache.storePermanentItem('key1', 1);
+
+memoryCache.setItemTimeToLiveRemaining('key1', 5); // expire in 5 seconds from now instead of never
+```
+#### To an absolute expiration time
+```ts
+import { MemoryCache } from 'memory-cache-node';
+
+const memoryCache = new MemoryCache<string, number>(600, 1000000);
+memoryCache.storeExpiringItem('key1', 1, 60);
+
+// Expire at the end of this year, instead of in 60 seconds:
+const endOfThisYear = new Date(new Date().getFullYear(), 11, 31);
+memoryCache.setItemTimeToLiveUntil('key1', endOfThisYear.getTime());
+```
+
 ### Getting the item expiration timestamp
 ```ts
 import { MemoryCache } from 'memory-cache-node';
@@ -150,6 +174,8 @@ class MemoryCache<K, V> {
   getValues(): V[];
   getItems(): [K, V][];
   retrieveItemValue(itemKey: K): V | undefined;
+  setItemTimeToLiveUntil(itemKey: K, timeToLiveUntilInMillisSinceEpoch: number): void;
+  setItemTimeToLiveRemaining(itemKey: K, timeToLiveInSecs: number): void;
   getItemExpirationTimestampInMillisSinceEpoch(itemKey: K): number | undefined;
   removeItem(itemKey: K): void;
   exportItemsToJson(): string;

--- a/README.md
+++ b/README.md
@@ -90,15 +90,6 @@ console.log(memoryCache.retrieveItemValue('notFound')); // Logs to console: unde
 ### Changing the item expiration timestamp
 You can set the item expiration time for both permanent and already expiring items.
 
-#### With a relative expiration time
-```ts
-import { MemoryCache } from 'memory-cache-node';
-
-const memoryCache = new MemoryCache<string, number>(600, 1000000);
-memoryCache.storePermanentItem('key1', 1);
-
-memoryCache.setItemTimeToLiveRemaining('key1', 5); // expire in 5 seconds from now instead of never
-```
 #### To an absolute expiration time
 ```ts
 import { MemoryCache } from 'memory-cache-node';
@@ -109,6 +100,16 @@ memoryCache.storeExpiringItem('key1', 1, 60);
 // Expire at the end of this year, instead of in 60 seconds:
 const endOfThisYear = new Date(new Date().getFullYear(), 11, 31);
 memoryCache.setItemTimeToLiveUntil('key1', endOfThisYear.getTime());
+```
+
+#### With a relative expiration time
+```ts
+import { MemoryCache } from 'memory-cache-node';
+
+const memoryCache = new MemoryCache<string, number>(600, 1000000);
+memoryCache.storePermanentItem('key1', 1);
+
+memoryCache.setItemTimeToLiveRemaining('key1', 5); // expire in 5 seconds from now instead of never
 ```
 
 #### Making an expiring item permanent

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ class MemoryCache<K, V> {
   getItems(): [K, V][];
   retrieveItemValue(itemKey: K): V | undefined;
   setItemTimeToLiveUntil(itemKey: K, timeToLiveUntilInMillisSinceEpoch: number | undefined): void;
-  setItemTimeToLiveRemaining(itemKey: K, timeToLiveInSecs: number): void;
+  setItemTimeToLiveRemaining(itemKey: K, timeToLiveInSecs: number | undefined): void;
   getItemExpirationTimestampInMillisSinceEpoch(itemKey: K): number | undefined;
   removeItem(itemKey: K): void;
   exportItemsToJson(): string;

--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ const endOfThisYear = new Date(new Date().getFullYear(), 11, 31);
 memoryCache.setItemTimeToLiveUntil('key1', endOfThisYear.getTime());
 ```
 
+#### Making an expiring item permanent
+```ts
+import { MemoryCache } from 'memory-cache-node';
+
+const memoryCache = new MemoryCache<string, number>(600, 1000000);
+memoryCache.storeExpiringItem('key1', 1, 60);
+
+memoryCache.setItemTimeToLiveUntil('key1', undefined); // Never expire
+```
+
 ### Getting the item expiration timestamp
 ```ts
 import { MemoryCache } from 'memory-cache-node';

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ class MemoryCache<K, V> {
   getValues(): V[];
   getItems(): [K, V][];
   retrieveItemValue(itemKey: K): V | undefined;
-  setItemTimeToLiveUntil(itemKey: K, timeToLiveUntilInMillisSinceEpoch: number): void;
+  setItemTimeToLiveUntil(itemKey: K, timeToLiveUntilInMillisSinceEpoch: number | undefined): void;
   setItemTimeToLiveRemaining(itemKey: K, timeToLiveInSecs: number): void;
   getItemExpirationTimestampInMillisSinceEpoch(itemKey: K): number | undefined;
   removeItem(itemKey: K): void;

--- a/src/MemoryCache.spec.ts
+++ b/src/MemoryCache.spec.ts
@@ -141,6 +141,15 @@ describe('MemoryCache', () => {
       const newExpirationTimestamp = memoryCache.getItemExpirationTimestampInMillisSinceEpoch('key');
       expect(newExpirationTimestamp).toBeCloseTo(calculatedExpirationTimestmap, -2);
     });
+
+    it('should make an item permanent', () => {
+      memoryCache = new MemoryCache<string, number>(1, 10);
+      memoryCache.storePermanentItem('key', 2);
+
+      memoryCache.setItemTimeToLiveRemaining('key', undefined);
+      const newExpirationTimestamp = memoryCache.getItemExpirationTimestampInMillisSinceEpoch('key');
+      expect(newExpirationTimestamp).toBe(undefined);
+    });
   });
 
   describe('setItemTimeToLiveUntil', () => {

--- a/src/MemoryCache.spec.ts
+++ b/src/MemoryCache.spec.ts
@@ -130,6 +130,31 @@ describe('MemoryCache', () => {
     });
   });
 
+  describe('setItemTimeToLiveRemaining', () => {
+    it('should change a permanent item to temporary', () => {
+      memoryCache = new MemoryCache<string, number>(1, 10);
+      memoryCache.storePermanentItem('key', 2);
+
+      const timeToLiveInSecs = 10;
+      const calculatedExpirationTimestmap = Date.now() + timeToLiveInSecs * 1000;
+      memoryCache.setItemTimeToLiveRemaining('key', timeToLiveInSecs);
+      const newExpirationTimestamp = memoryCache.getItemExpirationTimestampInMillisSinceEpoch('key');
+      expect(newExpirationTimestamp).toBeCloseTo(calculatedExpirationTimestmap, -2);
+    });
+  });
+
+  describe('setItemTimeToLiveUntil', () => {
+    it('should take an absolute value at which the item should expire', () => {
+      memoryCache = new MemoryCache<string, number>(1, 10);
+      memoryCache.storeExpiringItem('key', 2, 10);
+
+      const timeToLiveUntil = Date.now() + 10000;
+      memoryCache.setItemTimeToLiveUntil('key', timeToLiveUntil);
+      const originalExpirationTimestamp = memoryCache.getItemExpirationTimestampInMillisSinceEpoch('key');
+      expect(originalExpirationTimestamp).toBe(timeToLiveUntil);
+    });
+  });
+
   describe('getItemExpirationTimestampInMillisSinceEpoch', () => {
     it('should return the item expiration timestamp if cache contains item with given key', () => {
       memoryCache = new MemoryCache<string, number>(1, 10);
@@ -184,7 +209,7 @@ describe('MemoryCache', () => {
       const itemsObject = {
         key: { value: 1, expirationTimestampInMillis: 1 },
         key2: { value: 2, expirationTimestampInMillis: 2 },
-      }
+      };
 
       memoryCache.importItemsFrom(JSON.stringify(itemsObject));
       expect(memoryCache.getItemCount()).toBe(2);

--- a/src/MemoryCache.spec.ts
+++ b/src/MemoryCache.spec.ts
@@ -153,6 +153,15 @@ describe('MemoryCache', () => {
       const newExpirationTimestamp = memoryCache.getItemExpirationTimestampInMillisSinceEpoch('key');
       expect(newExpirationTimestamp).toBe(timeToLiveUntil);
     });
+
+    it('should make an item permanent', () => {
+      memoryCache = new MemoryCache<string, number>(1, 10);
+      memoryCache.storeExpiringItem('key', 2, 10);
+
+      memoryCache.setItemTimeToLiveUntil('key', undefined);
+      const newExpirationTimestamp = memoryCache.getItemExpirationTimestampInMillisSinceEpoch('key');
+      expect(newExpirationTimestamp).toBe(undefined);
+    });
   });
 
   describe('getItemExpirationTimestampInMillisSinceEpoch', () => {

--- a/src/MemoryCache.spec.ts
+++ b/src/MemoryCache.spec.ts
@@ -150,8 +150,8 @@ describe('MemoryCache', () => {
 
       const timeToLiveUntil = Date.now() + 10000;
       memoryCache.setItemTimeToLiveUntil('key', timeToLiveUntil);
-      const originalExpirationTimestamp = memoryCache.getItemExpirationTimestampInMillisSinceEpoch('key');
-      expect(originalExpirationTimestamp).toBe(timeToLiveUntil);
+      const newExpirationTimestamp = memoryCache.getItemExpirationTimestampInMillisSinceEpoch('key');
+      expect(newExpirationTimestamp).toBe(timeToLiveUntil);
     });
   });
 

--- a/src/MemoryCache.spec.ts
+++ b/src/MemoryCache.spec.ts
@@ -130,6 +130,27 @@ describe('MemoryCache', () => {
     });
   });
 
+  describe('setItemTimeToLiveUntil', () => {
+    it('should take an absolute value at which the item should expire', () => {
+      memoryCache = new MemoryCache<string, number>(1, 10);
+      memoryCache.storeExpiringItem('key', 2, 10);
+
+      const timeToLiveUntil = Date.now() + 10000;
+      memoryCache.setItemTimeToLiveUntil('key', timeToLiveUntil);
+      const newExpirationTimestamp = memoryCache.getItemExpirationTimestampInMillisSinceEpoch('key');
+      expect(newExpirationTimestamp).toBe(timeToLiveUntil);
+    });
+
+    it('should make an item permanent', () => {
+      memoryCache = new MemoryCache<string, number>(1, 10);
+      memoryCache.storeExpiringItem('key', 2, 10);
+
+      memoryCache.setItemTimeToLiveUntil('key', undefined);
+      const newExpirationTimestamp = memoryCache.getItemExpirationTimestampInMillisSinceEpoch('key');
+      expect(newExpirationTimestamp).toBe(undefined);
+    });
+  });
+
   describe('setItemTimeToLiveRemaining', () => {
     it('should change a permanent item to temporary', () => {
       memoryCache = new MemoryCache<string, number>(1, 10);
@@ -147,27 +168,6 @@ describe('MemoryCache', () => {
       memoryCache.storePermanentItem('key', 2);
 
       memoryCache.setItemTimeToLiveRemaining('key', undefined);
-      const newExpirationTimestamp = memoryCache.getItemExpirationTimestampInMillisSinceEpoch('key');
-      expect(newExpirationTimestamp).toBe(undefined);
-    });
-  });
-
-  describe('setItemTimeToLiveUntil', () => {
-    it('should take an absolute value at which the item should expire', () => {
-      memoryCache = new MemoryCache<string, number>(1, 10);
-      memoryCache.storeExpiringItem('key', 2, 10);
-
-      const timeToLiveUntil = Date.now() + 10000;
-      memoryCache.setItemTimeToLiveUntil('key', timeToLiveUntil);
-      const newExpirationTimestamp = memoryCache.getItemExpirationTimestampInMillisSinceEpoch('key');
-      expect(newExpirationTimestamp).toBe(timeToLiveUntil);
-    });
-
-    it('should make an item permanent', () => {
-      memoryCache = new MemoryCache<string, number>(1, 10);
-      memoryCache.storeExpiringItem('key', 2, 10);
-
-      memoryCache.setItemTimeToLiveUntil('key', undefined);
       const newExpirationTimestamp = memoryCache.getItemExpirationTimestampInMillisSinceEpoch('key');
       expect(newExpirationTimestamp).toBe(undefined);
     });

--- a/src/MemoryCache.ts
+++ b/src/MemoryCache.ts
@@ -1,6 +1,6 @@
 export type ValueWrapper<V> = {
   readonly value: V;
-  readonly expirationTimestampInMillis: number | undefined;
+  expirationTimestampInMillis: number | undefined;
 };
 
 export default class MemoryCache<K, V> {
@@ -58,6 +58,22 @@ export default class MemoryCache<K, V> {
     return this.itemKeyToValueWrapperMap.get(itemKey)?.value;
   }
 
+  setItemTimeToLiveUntil(itemKey: K, timeToLiveUntilInMillisSinceEpoch: number): void {
+    const valueWrapper = this.itemKeyToValueWrapperMap.get(itemKey);
+
+    if (valueWrapper !== undefined) {
+      valueWrapper.expirationTimestampInMillis = timeToLiveUntilInMillisSinceEpoch;
+    }
+  }
+
+  setItemTimeToLiveRemaining(itemKey: K, timeToLiveInSecs: number): void {
+    const valueWrapper = this.itemKeyToValueWrapperMap.get(itemKey);
+
+    if (valueWrapper !== undefined) {
+      valueWrapper.expirationTimestampInMillis = Date.now() + timeToLiveInSecs * 1000;
+    }
+  }
+
   getItemExpirationTimestampInMillisSinceEpoch(itemKey: K): number | undefined {
     return this.itemKeyToValueWrapperMap.get(itemKey)?.expirationTimestampInMillis;
   }
@@ -104,7 +120,7 @@ export default class MemoryCache<K, V> {
         if (this.itemCount < this.maxItemCount) {
           this.itemKeyToValueWrapperMap.set(key as any, {
             value,
-            expirationTimestampInMillis
+            expirationTimestampInMillis,
           });
 
           this.itemCount++;

--- a/src/MemoryCache.ts
+++ b/src/MemoryCache.ts
@@ -66,7 +66,11 @@ export default class MemoryCache<K, V> {
     }
   }
 
-  setItemTimeToLiveRemaining(itemKey: K, timeToLiveInSecs: number): void {
+  setItemTimeToLiveRemaining(itemKey: K, timeToLiveInSecs: number | undefined): void {
+    if (timeToLiveInSecs === undefined) {
+      return this.setItemTimeToLiveUntil(itemKey, undefined);
+    }
+
     const valueWrapper = this.itemKeyToValueWrapperMap.get(itemKey);
 
     if (valueWrapper !== undefined) {

--- a/src/MemoryCache.ts
+++ b/src/MemoryCache.ts
@@ -58,7 +58,7 @@ export default class MemoryCache<K, V> {
     return this.itemKeyToValueWrapperMap.get(itemKey)?.value;
   }
 
-  setItemTimeToLiveUntil(itemKey: K, timeToLiveUntilInMillisSinceEpoch: number): void {
+  setItemTimeToLiveUntil(itemKey: K, timeToLiveUntilInMillisSinceEpoch: number | undefined): void {
     const valueWrapper = this.itemKeyToValueWrapperMap.get(itemKey);
 
     if (valueWrapper !== undefined) {


### PR DESCRIPTION
Hi there! Thanks for this library, it may be of good use for one of my projects.

Whilst looking into your library I thought it was missing a feature: **the ability to change an item's expiry time.** 

At the cost of getting ahead of myself: I've already implemented it, written some tests and updated your README 😅. I hope I can now make you see the value of this feature.

Feel free to let me know if I can help by changing something to have this PR better fit your design, ideas or goals.

## Example use-case
I am making a multiplayer game. In order to keep online player data readily available I will use this memory cache. When they disconnect I'll remove their entry from the cache. 

Sometimes a player may timeout, go AFK, or otherwise become unavailable. I'd like the cache to not have to keep that data in memory unnecessarily. Therefor I'm setting a player's item with `memoryCache.storeExpiringItem('player-id-here', playerData, 60);`.

However if the player interacts with the game in any way, I want to tell the cache that it shouldn't expire the data just yet. For that reason a function like this would really help to delay the removal again: `memoryCache.setItemTimeToLiveRemaining('player-id-here', 60);`

## Usage
There's two new functions that can be used to set an item's time to live.

_(Excerpt from the updated README)_

#### With a relative expiration time
```ts
import { MemoryCache } from 'memory-cache-node';

const memoryCache = new MemoryCache<string, number>(600, 1000000);
memoryCache.storePermanentItem('key1', 1);

memoryCache.setItemTimeToLiveRemaining('key1', 5); // expire in 5 seconds from now instead of never
```
#### To an absolute expiration time
```ts
import { MemoryCache } from 'memory-cache-node';

const memoryCache = new MemoryCache<string, number>(600, 1000000);
memoryCache.storeExpiringItem('key1', 1, 60);

// Expire at the end of this year, instead of in 60 seconds:
const endOfThisYear = new Date(new Date().getFullYear(), 11, 31);
memoryCache.setItemTimeToLiveUntil('key1', endOfThisYear.getTime());
```