### PR TITLE
chore: unref timer

### DIFF
--- a/src/MemoryCache.ts
+++ b/src/MemoryCache.ts
@@ -14,6 +14,9 @@ export default class MemoryCache<K, V> {
     private readonly maxItemCount: number
   ) {
     this.timer = setInterval(this.deleteExpiredItems, itemsExpirationCheckIntervalInSecs * 1000);
+    if( this.timer.unref ){
+      this.timer.unref();
+    }
   }
 
   storePermanentItem(key: K, value: V): void {


### PR DESCRIPTION
from https://nodejs.org/api/timers.html#timeoutunref

When called, the active Timeout object will not require the Node.js event loop to remain active. If there is no other activity keeping the event loop running, the process may exit before the Timeout object's callback is invoked.